### PR TITLE
Add linear search implementation in Go

### DIFF
--- a/search/linear_search/linearsearch.go
+++ b/search/linear_search/linearsearch.go
@@ -1,0 +1,27 @@
+package main
+
+import "fmt"
+
+// LinearSearch search for an item in a list in linear time
+func LinearSearch(items []int, item int) (int, error) {
+	for i, _ := range items {
+		if items[i] == item {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("Item '%v' not found", item)
+}
+
+func main() {
+	items := []int{-1, 0, 2, 4, 6, 3, 5, 7, 8, -4}
+	inputs := []int{-1, 3, 300}
+
+	for _, in := range inputs {
+		index, err := LinearSearch(items, in)
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(index)
+		}
+	}
+}

--- a/search/linear_search/linearsearch_test.go
+++ b/search/linear_search/linearsearch_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+var (
+	items = []int{-1, 0, 2, 4, 6, 3, 5, 7, 8, -4}
+
+	testTable = []struct {
+		item, expected int
+		err            error
+	}{
+		{-1, 0, nil},
+		{1000, -1, fmt.Errorf("Item '%v' not found", 1000)},
+		{7, 7, nil},
+	}
+)
+
+func TestLinearSearch(t *testing.T) {
+	for _, testCase := range testTable {
+		got, err := LinearSearch(items, testCase.item)
+
+		if got != testCase.expected || (err != nil && err.Error() != testCase.err.Error()) {
+			t.Errorf("LinearSearch(%v, %v): expected (%v, %v), actual (%v, %v)", items, testCase.item, testCase.expected, testCase.err, got, err)
+		}
+	}
+}


### PR DESCRIPTION
The Pull Request resolves Issue #52 

Description:
Add linear search implementation in Go. Tests are included.

Notes:
- Execute by running `go run linearsearch.go` in a terminal window.
- Execute tests by running `go test`.

**_The commands above must be executed within the solution folder._**